### PR TITLE
Fixed Discord invite links by removing the / at the end.

### DIFF
--- a/docs/BedWars2023/home.md
+++ b/docs/BedWars2023/home.md
@@ -5,7 +5,7 @@ sidebar_position: 0
 sidebar_label: Home
 ---
 
-[![Discord](https://img.shields.io/discord/760851292826107926)](https://discord.gg/kPaBGwhmjf/)
+[![Discord](https://img.shields.io/discord/760851292826107926)](https://discord.gg/kPaBGwhmjf)
 [![Servers](https://img.shields.io/bstats/servers/18317)](https://bstats.org/plugin/bukkit/BedWars2023/)
 
 Welcome to the BedWars2023 wiki. Here you will find a complete set of documentation for the plugin, outlining how to install, setup, configure and effectively use BedWars2023.

--- a/docs/BedWarsProxy/home.md
+++ b/docs/BedWarsProxy/home.md
@@ -5,7 +5,7 @@ sidebar_position: 0
 sidebar_label: Home
 ---
 
-[![Discord](https://img.shields.io/discord/760851292826107926)](https://discord.gg/kPaBGwhmjf/)
+[![Discord](https://img.shields.io/discord/760851292826107926)](https://discord.gg/kPaBGwhmjf)
 [![Servers](https://img.shields.io/bstats/servers/18317)](https://bstats.org/plugin/bukkit/BedWars2023/)
 
 Welcome to the BedWarsProxy wiki. Here you will find a complete set of documentation for the plugin, outlining how to install, setup, configure and effectively use BedWarsProxy in combination with BedWars2023.


### PR DESCRIPTION
If you add a / at the end of any Discord invite link, it breaks and it sends you to discord.com instead of the server.